### PR TITLE
Add if statement for m_WLANMAC #52

### DIFF
--- a/app/src/main/java/pbell/offline/ole/org/pbell/FullscreenActivity.java
+++ b/app/src/main/java/pbell/offline/ole/org/pbell/FullscreenActivity.java
@@ -1769,7 +1769,14 @@ public class FullscreenActivity extends AppCompatActivity {
             manager = new Manager(androidContext, Manager.DEFAULT_OPTIONS);
             activityLog = manager.getDatabase("activitylog");
             WifiManager wm = (WifiManager) getSystemService(Context.WIFI_SERVICE);
-            String m_WLANMAC = wm.getConnectionInfo().getMacAddress();
+
+            //This is for setting the MAC address if it is being run in a android emulator.
+            String m_WLANMAC;
+            m_WLANMAC = wm.getConnectionInfo().getMacAddress();
+            if(m_WLANMAC == null) {
+                m_WLANMAC = "mymac";
+            }
+
             Document retrievedDocument = activityLog.getDocument(m_WLANMAC);
             Map<String, Object> properties = retrievedDocument.getProperties();
             if ((ArrayList<String>) properties.get("female_opened") != null) {

--- a/app/src/main/java/pbell/offline/ole/org/pbell/FullscreenLogin.java
+++ b/app/src/main/java/pbell/offline/ole/org/pbell/FullscreenLogin.java
@@ -612,7 +612,14 @@ public class FullscreenLogin extends AppCompatActivity {
             manager = new Manager(androidContext, Manager.DEFAULT_OPTIONS);
             activityLog = manager.getDatabase("activitylog");
             WifiManager wm = (WifiManager) getSystemService(Context.WIFI_SERVICE);
-            String m_WLANMAC = wm.getConnectionInfo().getMacAddress();
+
+            //This is for setting the MAC address if it is being run in a android emulator.
+            String m_WLANMAC;
+            m_WLANMAC = wm.getConnectionInfo().getMacAddress();
+            if(m_WLANMAC == null) {
+                m_WLANMAC = "mymac";
+            }
+
             Document retrievedDocument = activityLog.getDocument(m_WLANMAC);
             if (retrievedDocument != null) {
                 if (retrievedDocument.getProperties() != null) {


### PR DESCRIPTION
I modified the ``` m_WLANMAC ``` variable declination into a ```if``` statement. Basically, if it is unable to obtain a MAC address it will assign the dummy mac address variable ``` "mymac" ```. I would like other people to test this in their virtual Android Device and on their own physical Android device before we merge this pull request.

I added this 'if' statement so future people working on Android Take Home don't have to modify there MAC address every time they are trying to work on the project.